### PR TITLE
Fixes typos in "Eligible Performer Aliases"

### DIFF
--- a/docs/performers.md
+++ b/docs/performers.md
@@ -105,7 +105,7 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 - **Prefer unique names over commonly used aliases, but otherwise no hard rules only suggestions.**
 
 ### [Eligible Performer Aliases](performer-names-and-aliases#eligible-performer-aliases)
-- **Must have be used as an official adult credit, no legal names allowed except when a stage name is also their given name.**
+- **Must be an official adult credit, no legal names allowed except when a stage name is also their given name.**
 
 ### [JAV Performer Names](performer-names-and-aliases#jav-performer-names)
 - **Western order with simplified Latin characters as default primary name, all other spellings as aliases.**

--- a/docs/performers/performer-names-and-aliases.md
+++ b/docs/performers/performer-names-and-aliases.md
@@ -32,7 +32,7 @@ Also be aware that names are only eligible to be primary names if they've been u
 _Unconfirmed guideline, subject to change pending formal approval._
 
 ### Eligible Performer Aliases
-- **Must have be used as an official adult credit, no legal names allowed except when a stage name is also their given name.**
+- **Must be an official adult credit, no legal names allowed except when a stage name is also their given name.**
 
 Performer aliases must be names that have been used as official credits in an adult video performance. They do not have to be names used as performance aliases in a scene already listed on StashDB. This means that names that have been used professionally in non-adult mainstream performances, listed in credits or bylines as a writer or author, used on public social media accounts, or listed in news articles are not eligible to be listed on StashDB unless they've also been used as an official adult credit.
 


### PR DESCRIPTION
Typo is in both locations of the one-line summary. Using this as a test of a new PR workflow.