### PR TITLE
Add "Capitalizing Tag Names and Aliases"

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,8 +24,10 @@ Everything here is listed in reverse chronological order with the most recent up
 ## 2022
 
 ### December 2022
+- Add "Capitalizing Tag Names and Aliases", by [@AdultSun] in [PR #13] and [approved in this thread on Discord](https://discord.com/channels/559159668438728723/1038607732116303943)
 - Creates changelog, by [@AdultSun] in [PR #12]
 
+[PR #13]: https://github.com/stashapp/StashDB-Docs/pull/13
 [PR #12]: https://github.com/stashapp/StashDB-Docs/pull/12
 
 ### November 2022

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -109,5 +109,5 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 ## **[Tag Style Guide](tag-style-guide)**
 The following sections have been [formally approved]({{ site.baseurl }}/docs/getting-started-stashdb/#guideline-proposals) unless stated otherwise. Contributors are still expected to follow any [unconfirmed guidelines]({{ site.baseurl }}/docs/getting-started-stashdb/#unconfirmed-guidelines), but should know that they are subject to change in the near future. Failure to follow any of these guidelines may result in rejected submissions.
 
-### [Capitalizing Names and Aliases](tag-style-guide#capitalizing-names-and-aliases)
+### [Capitalizing Tag Names and Aliases](tag-style-guide#capitalizing-tag-names-and-aliases)
   - **Title casing for words and phrases, all-caps with no punctuation for acronyms.**

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -98,16 +98,16 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 
 ***
 
-## **[Editing Tags](editing-tags)**
-The following sections have been [formally approved]({{ site.baseurl }}/docs/getting-started-stashdb/#guideline-proposals) unless stated otherwise. Contributors are still expected to follow any [unconfirmed guidelines]({{ site.baseurl }}/docs/getting-started-stashdb/#unconfirmed-guidelines), but should know that they are subject to change in the near future. Failure to follow any of these guidelines may result in rejected submissions.
-
-### [Style Guide](editing-tags#style-guide)
-  - **TBD.**
-
-***
-
 ## **[Merging Tags](merging-tags)**
 The following sections have been [formally approved]({{ site.baseurl }}/docs/getting-started-stashdb/#guideline-proposals) unless stated otherwise. Contributors are still expected to follow any [unconfirmed guidelines]({{ site.baseurl }}/docs/getting-started-stashdb/#unconfirmed-guidelines), but should know that they are subject to change in the near future. Failure to follow any of these guidelines may result in rejected submissions.
 
 ### [Merging Sorted Tags](merging-tags#merging-sorted-tags)
   - **"Sorted" tags (already has category/description) shouldn't be considered eligible to be deleted or merged. Ask on Discord first if you think you've found an exception.**
+
+***
+
+## **[Tag Style Guide](tag-style-guide)**
+The following sections have been [formally approved]({{ site.baseurl }}/docs/getting-started-stashdb/#guideline-proposals) unless stated otherwise. Contributors are still expected to follow any [unconfirmed guidelines]({{ site.baseurl }}/docs/getting-started-stashdb/#unconfirmed-guidelines), but should know that they are subject to change in the near future. Failure to follow any of these guidelines may result in rejected submissions.
+
+### [Capitalizing Names and Aliases](tag-style-guide#capitalizing-names-and-aliases)
+  - **Title casing for words and phrases, all-caps with no punctuation for acronyms.**

--- a/docs/tags/merging-tags.md
+++ b/docs/tags/merging-tags.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: "Merging Tags"
-nav_order: 5
+nav_order: 4
 parent: Tags
 ---
 

--- a/docs/tags/tag-style-guide.md
+++ b/docs/tags/tag-style-guide.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: "Editing Tags"
-nav_order: 4
+title: "Tag Style Guide"
+nav_order: 5
 parent: Tags
 ---
 
-# **Editing Tags**
+# **Tag Style Guide**
 {: .no_toc }
 The following sections have been [formally approved]({{ site.baseurl }}/docs/getting-started-stashdb/#guideline-proposals) unless stated otherwise. Contributors are still expected to follow any [unconfirmed guidelines]({{ site.baseurl }}/docs/getting-started-stashdb/#unconfirmed-guidelines), but should know that they are subject to change in the near future. Failure to follow any of these guidelines may result in rejected submissions.
 
@@ -22,7 +22,7 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 
 ***
 
-### Style Guide
+### Capitalizing Names and Aliases
 - **TBD.**
 
 Placeholder description, ask on [Discord]({{ site.baseurl }}/docs/getting-started-stashdb/#joining-our-discord).

--- a/docs/tags/tag-style-guide.md
+++ b/docs/tags/tag-style-guide.md
@@ -23,8 +23,8 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 ***
 
 ### Capitalizing Names and Aliases
-- **TBD.**
+- **Title casing for words and phrases, all-caps with no punctuation for acronyms.**
 
-Placeholder description, ask on [Discord]({{ site.baseurl }}/docs/getting-started-stashdb/#joining-our-discord).
+Tag names and aliases should follow [proper title-casing](https://capitalizemytitle.com/style/AP/) for individual words and phrases. This means most words will only have the first letter capitalized but small words in the middle of a phrase (prepositions, conjunctions, articles, etc.) should be left completely lower case. For example, `Missing or Removed` would be correct. `Missing Or Removed`, `missing or removed`, and `MISSING OR REMOVED` would be incorrect.
 
-_Unconfirmed guideline, subject to change pending formal approval._
+However, every letters should be capitalized for acronyms. There should also be no punctuation between each letter. For example, `BDSM` would be correct. `Bdsm`, `bdsm`, and `B.D.S.M.` would be incorrect.

--- a/docs/tags/tag-style-guide.md
+++ b/docs/tags/tag-style-guide.md
@@ -27,4 +27,4 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 
 Tag names and aliases should follow [proper title-casing](https://capitalizemytitle.com/style/AP/) for individual words and phrases. This means most words will only have the first letter capitalized but small words in the middle of a phrase (prepositions, conjunctions, articles, etc.) should be left completely lower case. For example, `Missing or Removed` would be correct. `Missing Or Removed`, `missing or removed`, and `MISSING OR REMOVED` would be incorrect.
 
-However, every letters should be capitalized for acronyms. There should also be no punctuation between each letter. For example, `BDSM` would be correct. `Bdsm`, `bdsm`, and `B.D.S.M.` would be incorrect.
+However, every letter should be capitalized for acronyms. There should also be no punctuation between each letter. For example, `BDSM` would be correct. `Bdsm`, `bdsm`, and `B.D.S.M.` would be incorrect.

--- a/docs/tags/tag-style-guide.md
+++ b/docs/tags/tag-style-guide.md
@@ -22,7 +22,7 @@ The following sections have been [formally approved]({{ site.baseurl }}/docs/get
 
 ***
 
-### Capitalizing Names and Aliases
+### Capitalizing Tag Names and Aliases
 - **Title casing for words and phrases, all-caps with no punctuation for acronyms.**
 
 Tag names and aliases should follow [proper title-casing](https://capitalizemytitle.com/style/AP/) for individual words and phrases. This means most words will only have the first letter capitalized but small words in the middle of a phrase (prepositions, conjunctions, articles, etc.) should be left completely lower case. For example, `Missing or Removed` would be correct. `Missing Or Removed`, `missing or removed`, and `MISSING OR REMOVED` would be incorrect.


### PR DESCRIPTION
Adds section for "Capitalizing Tag Names and Aliases", covered by issue #10 and approved by [this Discord thread](https://discord.com/channels/559159668438728723/1038607732116303943).

This also renames the placeholder "Editing Tags" page to "Tag Style Guide". This feels like a better fit for the few sections relating to tags that don't already fall under the other existing pages.

I also realized while writing this that the thread proposal says that it's intended "to formalize the current consensus" by "capitalizing the first letter of each word", which is actually a contradiction. The current prevailing format is title-casing, meaning small words like "in" or "and" are left completely lower case. I hadn't noticed this before, it really should've been clarified in the proposal before I submitted it for approval. I wrote the new section as prioritizing "formalize current consensus" so it explains which words are excluded from capitalization and links to an AP style converter.

I'll post a link to the PR in the Ministry for approval before merging.