### PR TITLE
Corrected broken link

### DIFF
--- a/docs/studios/create/classic-studios.md
+++ b/docs/studios/create/classic-studios.md
@@ -13,7 +13,7 @@ grand_parent: Studios
 
 ---
 
-Older studios are currently allowed on StashDB only in limited circumstances. Studios and scenes that pre-date digital distribution where content is only available as rips of home video releases or third party resellers are not allowed on StashDB at this time. This includes content that can only be sourced from marketplaces that sell digital scenes and movies like Adult DVD Empire or Hot Movies. At this time, all professional scenes and studios must be available digitally from an official studio website or network. The reasoning for this is due to a desire to move slowly with this content, so it may change in the future. Please also see our policy on [full movie scene entries]({{ site.baseurl }}/docs/scenes/create/full-dvd-entries/).
+Older studios are currently allowed on StashDB only in limited circumstances. Studios and scenes that pre-date digital distribution where content is only available as rips of home video releases or third party resellers are not allowed on StashDB at this time. This includes content that can only be sourced from marketplaces that sell digital scenes and movies like Adult DVD Empire or Hot Movies. At this time, all professional scenes and studios must be available digitally from an official studio website or network. The reasoning for this is due to a desire to move slowly with this content, so it may change in the future. Please also see our policy on [full movie scene entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/).
 
 {: .note }
 Unconfirmed guideline, subject to change pending formal approval.


### PR DESCRIPTION
Changed the link for "full movie scene entries" because the current one gave a 404. Following the URL structure, my suggested replacement is the correct destination.