### PR TITLE
Update personal-links.md

### DIFF
--- a/docs/performers/edit/performer-links/personal-links.md
+++ b/docs/performers/edit/performer-links/personal-links.md
@@ -14,4 +14,4 @@ grand_parent: Edit Performers
 
 ---
 
-Links to a performer's personal accounts are disallowed unless they are explicitly tied to a professional account. The distinction of a personal account is one that has no association with their profession and may include personal details including but not limited to their real name.
+Links to a performer's personal accounts are disallowed unless they are explicitly tied to a professional account. The distinction of a personal account is one that has no association with their pornographic profession and may include personal details including but not limited to their real name. Links to escort service accounts, e.g., SexyJobs, is prohibited unless the performer has linked to them from their pronographic performer account.


### PR DESCRIPTION
- Added clarification to prohibit escort service accounts unless associated with pornographic accounts.
- Added subtle clarification that the term profession means pornographic in nature -- "**pornographic** profession" --  to differentiate from other sex work which may not qualify.