### PR TITLE
Replace onboarding guide for new editors

### DIFF
--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -24,6 +24,8 @@ The process for gaining edit access is simple. First, you must read this **entir
 
 First, make sure you have an account on **StashDB.org**. There are other public stash-boxes that look very similar, but those are all hosted separately and require different accounts. We can't apply the EDIT role to an account that doesn't exist yet. Please see our guide to [Accessing StashDB]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stashdb/) if you need any help finding an invite code, registering an account, or connecting it to Stash.
 
+---
+
 ## Make a Discourse Account
 
 You will also be **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access.
@@ -33,6 +35,8 @@ You may also [join our Discord]({{ site.baseurl }}/docs/faq_getting-started/stas
 **For Discord users**, we require your nickname (also called "display name") in our server to match your StashDB username. You can either [go to your user settings](https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames){:target="_blank"} or type the shortcut `/nick <your-new-username>` into any channel of Stash's Discord server. This will only change the name displayed inside of Stash's Discord and not anywhere else. You may also request an admin to change your StashDB username instead (see below).
 
 If you would like to **change your StashDB username**, please contact a StashDB admin on Discourse/Discord (preferably **@AdultSun**) and ask them politely to change it for you. You may be asked to DM the email address you used to join StashDB in order for the admin to verify your account. If there is any concern about your username, an admin may ask you to pick a different one before granting edit access.
+
+---
 
 ## Guidelines Summary
 
@@ -95,6 +99,8 @@ The underlying Stash-Box software will automatically warn you of any duplicates 
 ### **Familiarize yourself with our disciplinary process.**
 
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first. Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine. Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
+
+---
 
 ## Submitting Your Request
 

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -35,7 +35,7 @@ First, make sure you have an account on **StashDB.org**. It's easy to confuse it
 
 All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access. The website can be found here:
 
-[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank" .btn }
+[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank" .btn .btn-blue }
 
 ### Filling out your Discourse profile
 
@@ -48,18 +48,18 @@ If you've already created an account, you'll have to dig into your settings to a
 ### Requirements for StashDB editors:
 
 - You must add your **StashDB username** to your Discourse profile.
+    - If you want to change your StashDB username, you can ask for a new one within the edit request form. If that's the case, add your new StashDB username to Discourse **before submitting your edit request**.
 - If you've joined any other public stash-boxes, please add those usernames as well.
 - If you've joined the Stash Discord server, please add your **server nickname** (also called **display name**).
     - Editors are **not required** to join Discord.
     - Editors are **not required** to "Log in with Discord" or "Connect" Discord to their account.
 - We recommend that your name on StashDB, Discourse, and Discord all match in order to limit confusion.
-- If you want to change your StashDB username, you can ask for a new one within the edit request form.
 
 ---
 
 # Guidelines Summary
 
-All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks within each section.
+All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely and carefully --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks within each section.
 
 ---
 
@@ -67,7 +67,7 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ### 1.) Start slowly.
 
-> {: .note }
+> {: .note-title }
 > > Important!
 > >
 > > **Do not start by submitting 20+ edits immediately after gaining edit access. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
@@ -96,7 +96,7 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 > Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
 > 
-> {: .note }
+> {: .note-title }
 > > Important!
 > >
 > > **If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
@@ -105,7 +105,7 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 > In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
 > 
-> {: .note }
+> {: .note-title }
 > > Important!
 > >
 > > **If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
@@ -116,7 +116,7 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 > 
 > These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
 > 
-> {: .note }
+> {: .note-title }
 > > Important!
 > >
 > > **If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
@@ -177,19 +177,19 @@ Always act with the best interests of the community in mind. Make your best effo
 
 Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
 
-{: .note }
+{: .note-title }
 > Important!
 >
 > **If you see any behavior that should result in the loss of edit access, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ---
 
-## Submitting Your Request
+# Submitting Your Request
 
 Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the button at the bottom of this page. Then, click the "Request" button in the top-right corner. Make sure to fill out the entire form, but please keep your answers brief.
 
 An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
 
-If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article. Make sure you follow every instruction to the letter, however insignificant it may seem. You may submit a new request no sooner than 1 hour after your previous one.
+If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, first re-read this **entire** article closely and carefully. Make sure you follow every instruction to the letter, however insignificant it may seem. You may submit a new request no sooner than 1 hour after your previous one.
 
 [APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank" .btn .btn-blue }

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -20,6 +20,8 @@ The process for gaining edit access is simple. First, you must read this **entir
 {: .warning }
 **Please read the following sections carefully. Failing to follow these instructions may result in delays, rejections, or the loss of future editing privileges.**
 
+---
+
 ## Make a StashDB Account
 
 First, make sure you have an account on **StashDB.org**. There are other public stash-boxes that look very similar, but those are all hosted separately and require different accounts. We can't apply the EDIT role to an account that doesn't exist yet. Please see our guide to [Accessing StashDB]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stashdb/) if you need any help finding an invite code, registering an account, or connecting it to Stash.
@@ -28,13 +30,49 @@ First, make sure you have an account on **StashDB.org**. There are other public 
 
 ## Make a Discourse Account
 
-You will also be **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access.
+All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access.
 
-You may also [join our Discord]({{ site.baseurl }}/docs/faq_getting-started/stashdb/joining-discord-and-matrix/) if you'd like, but this is **not required** for StashDB editors. As a result, not all mods, admins, and devs will be available there.
+If you've already created in account in Discourse, you will need to fill out your profile before requesting edit access. This will link all of your related profiles together for easy reference. While you're there, make sure your Discourse username matches your StashDB username. If you have joined our Discord server, your nickname there must match as well. All three names (StashDB, Discord, Discourse) must be the same in order to be granted edit access.
 
-**For Discord users**, we require your nickname (also called "display name") in our server to match your StashDB username. You can either [go to your user settings](https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames){:target="_blank"} or type the shortcut `/nick <your-new-username>` into any channel of Stash's Discord server. This will only change the name displayed inside of Stash's Discord and not anywhere else. You may also request an admin to change your StashDB username instead (see below).
+The following sections will walk you through all of these steps. Follow whichever guide is relevant to you.
 
-If you would like to **change your StashDB username**, please contact a StashDB admin on Discourse/Discord (preferably **@AdultSun**) and ask them politely to change it for you. You may be asked to DM the email address you used to join StashDB in order for the admin to verify your account. If there is any concern about your username, an admin may ask you to pick a different one before granting edit access.
+### **If you have not joined our Discourse server:**
+Visit the following link and click on the "Sign Up" button in the top-right corner:
+https://discourse.stashapp.cc/
+
+A registration form will pop up. Fill out it out, following these instructions:
+1. Provide an email address. Discourse will send you an activation email, so make sure you have access to it. Please note, this address will be visible to our admins on the server.
+1. Provide a username for Discourse. For StashDB editors, this **username** must match your StashDB username.
+1. You'll see a field labelled "Name (optional)". You can **ignore** this field. It may be used for any alternative name you would like listed in your profile, but it is not required. It is not a username or a display name and does not need to match any other accounts.
+1. Add your StashDB username. Again, this must match your Discourse **username** to gain edit access.
+1. If you have joined our Discord server, add your **nickname** (also called "display name") in the field labelled "Discord (optional)". Editors are **not required** to join our Discord. However, for anyone on Discord with edit access, this nickname must also match your StashDB username.
+1. You are **not required** to link your Discord or GitHub accounts by clicking either of the "Log in with..." buttons to the right. If you want to contribute to the Stash project as a dev, then linking GitHub could be helpful. Otherwise, you can ignore both buttons.
+1. If you've created accounts on any other stash-boxes, you may add those usernames next. None of these other usernames are required to match your name on StashDB, Discourse, or Discord.
+1. One last time, make sure your StashDB, Discourse, and Discord names match. If you need help changing any of these, keep reading.
+
+### **If you've already joined our Discourse:**
+Log into Discourse and make sure your profile is filled out, following these instructions:
+1. Click on your circular avatar in the top-right. In the pop-up, click on the profile icon in the bottom-right corner, then click "Preferences" next to the gear icon to the left. Finally, click on the "Profile" tab near the top of the page. Scroll down past the field labelled "Web Site".
+1. Add your StashDB username. This must match your Discourse **username** to gain edit access.
+1. If you have joined our Discord server, add your **nickname** (also called "display name") in the field labelled "Discord (optional)". Editors are **not required** to join our Discord. However, for anyone on Discord with edit access, this nickname must also match your StashDB username.
+1. If you've created accounts on any other stash-boxes, you may add those usernames next. None of these other usernames are required to match your name on StashDB, Discourse, or Discord.
+1. One last time, make sure your StashDB, Discourse, and Discord names match. If you need help changing any of these, keep reading.
+
+### **If you need to change your StashDB username:**
+First, decide what your new StashDB username will be. Make sure your Discourse username and Discord nickname match this new StashDB username **before** requesting edit access. You will be able to request a new StashDB username as part of your application. If approved, an admin will change your username and grant edit permissions at the same time. If there is any concern about your username, an admin may ask you to pick a different one before granting edit access.
+
+If you want to change your StashDB username at any time **after** receiving edit access, you will need to send an admin a DM to politely ask them to change it for you. You will need to provide your current StashDB username, your new StashDB username, and the email linked to your StashDB account. Your email is used to verify the account and is only visible to admins. If you can't remember the exact address, log into StashDB and click on your username near the top-right corner.
+
+### **If you need to change your Discourse username:**
+All editors are required to have matching names on StashDB and Discourse. If you want to change your Discourse username to match your StashDB username, you must change it **before** requesting edit access, following these instructions:
+1. Log into Discourse and click on your circular avatar in the top-right. In the pop-up, click on the profile icon in the bottom-right corner, then click "Preferences" next to the gear icon to the left.
+1. Near the top of the page, click the pencil icon underneath "Username". Change this to match your StashDB username.
+1. Further down, you'll see a field laballed "Name". You can **ignore** this field. It may be used for any alternative name you would like listed in your profile, but it is not required. It is not a username or a display name and does not need to match any other accounts.
+
+### **If you need to change your Discord username:**
+Editors are **not required** to join our Discord. However, for anyone on Discord with edit access, this nickname must also match your StashDB username. If you want to change your Discord username to match your StashDB username, you must change it **before** requesting edit access.
+
+This can be done one of two ways. You can either go to your user settings to [change your server nicknames](https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames){:target="_blank"}, or type the shortcut `/nick <your-new-username>` into any channel of Stash's Discord server. Both methods only change the name displayed inside of Stash's Discord. It will not change your username or display name anywhere else on Discord.
 
 ---
 
@@ -42,61 +80,61 @@ If you would like to **change your StashDB username**, please contact a StashDB 
 
 All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely -- even if you think the topic is irrelevant to you -- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
 
-### **Start slowly.**
+### **1. Start slowly.**
 
 Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes.
 
 Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes. Read more about the process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
 
-### **Use helpful edit comments.**
+### **2. Use helpful edit comments.**
 
 You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources. Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
 
-### **Update pending edits.**
+### **3. Update pending edits.**
 
 If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
 
-### **No underage performers.**
+### **4. No underage performers.**
 
 Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/). Please DM an admin immediately if you see any underage content on StashDB.
 
-### **No banned studios.**
+### **5. No banned studios.**
 
 In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time. Please DM an admin immediately if you see any banned content on StashDB.
 
-### **No ineligible performer aliases.**
+### **6. No ineligible performer aliases.**
 
 All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves. These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible. If you see a suspicious name on StashDB, please DM an admin immediately.
 
-### **Review your drafts.**
+### **7. Review your drafts.**
 
 When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
 
-### **Generate pHashes.**
+### **8. Generate pHashes.**
 
 Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/). Speaking of secret sauces, do you have a favorite ice cream topping? Be sure to include your answer as an "additional comment" in your application, don't tell anyone else, and keep reading.
 
-### **Ineligible movie scenes.**
+### **9. Ineligible movie scenes.**
 
 All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/). Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
-### **Exceptions for amateur content.**
+### **10. Exceptions for amateur content.**
 
 All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/). Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
-### **Exceptions for JAV content.**
+### **11. Exceptions for JAV content.**
 
 Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline. We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
 
-### **Add or create missing performers.**
+### **12. Add or create missing performers.**
 
 All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
 
-### **Check for duplicates first.**
+### **13. Check for duplicates first.**
 
 The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
 
-### **Familiarize yourself with our disciplinary process.**
+### **14. Moderation and enforcement.**
 
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first. Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine. Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
 
@@ -104,4 +142,8 @@ At the discretion of the admins, your edit access may be revoked at any time. Ho
 
 ## Submitting Your Request
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, politely ask for edit access in Discourse using the link below. Remember to answer every question in the request form and wait patiently. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse. If you fail to follow **any part** of these instructions, your application may be rejected. The admin reviewing your request might not explain why. You must return here and carefully read the entire article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, log into Discourse and click the link at the bottom of this page. Then, click the "Request" button in the top right corner of the page. The application form will pop up. Make sure to answer all 10 questions in the request form, but please keep your answers brief. Double-check your answers and click "Submit Request" once you're finished. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+
+If you fail to follow **any part** of these instructions, your application may be rejected. Most likely, an admin will direct you back to this article. If you would like to try again, you must first carefully re-read the entire article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
+
+https://discourse.stashapp.cc/g/stashdb_editors

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -13,21 +13,89 @@ grand_parent: FAQ / Getting Started
 
 ---
 
-Every StashDB account is able to [submit fingerprints/hashes]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/) from within the [Scene Tagger](https://docs.stashapp.cc/beginner-guides/guide-to-scraping/#use-the-scene-tagger){:target="_blank"} view of Stash. This does not require any additional permissions. However, if you would like to add or edit any scenes/performers/studios/tags, you will need to be granted additional privileges. Keep reading to learn how to gain edit access to StashDB.
+Every StashDB account is able to [submit fingerprints/hashes]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/) from within the [Scene Tagger](https://docs.stashapp.cc/beginner-guides/guide-to-scraping/#use-the-scene-tagger){:target="_blank"} view of Stash. This does not require any additional permissions. However, if you would like to add or edit any scenes/performers/studios/tags, you will need to be granted additional privileges.
+
+The process for gaining edit access is simple. First, you must read this **entire** article carefully and closely, following **all** of its instructions. After you finish reading, you must fill out a short application form. Every request will be reviewed individually by one of the admins. There will be an opportunity to reapply if your first request is rejected. The application process is described in more detail within this article and should take about 15-20 minutes, mostly depending on how fast you can read.
 
 {: .warning }
 **Please read the following sections carefully. Failing to follow these instructions may result in delays, rejections, or the loss of future editing privileges.**
 
-First, make sure you **make an account on StashDB.org** if you haven't already. We can't apply the EDIT role to an account that doesn't exist yet. Please see our guide to [Accessing StashDB]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stashdb/) if you need any help finding an invite code, registering an account, or connecting it to Stash.
+## Make a StashDB Account
 
-You will also be **required to join either Discord or Matrix**. All active editors must be reachable through one or the other. This is because we have a limited comment system at this time with no direct messaging or notifications from within StashDB (this is currently being worked on so stay tuned for future updates). The [Joining Discord and Matrix]({{ site.baseurl }}/docs/faq_getting-started/stashdb/joining-discord-and-matrix/) page includes invite links for both servers and explains a few of the differences between them.
+First, make sure you have an account on **StashDB.org**. There are other public stash-boxes that look very similar, but those are all hosted separately and require different accounts. We can't apply the EDIT role to an account that doesn't exist yet. Please see our guide to [Accessing StashDB]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stashdb/) if you need any help finding an invite code, registering an account, or connecting it to Stash.
 
-**For Discord users**, we require your nickname in our server to match your StashDB username. It makes it easier for other editors to find you in case there are any questions or issues. You can either [go to your user settings](https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames){:target="_blank"} or type the shortcut `/nick <your-new-username>` into any channel of Stash's Discord server. This will not change your username or display name outside of Stash's Discord. You can also request an admin to change your StashDB username instead (see below).
+## Make a Discourse Account
 
-**For Matrix users**, we require your display name to match your StashDB username. It makes it easier for other editors to find you in case there are any questions or issues. The process will be slightly different depending on which client you're using. However, this will change your display name for your entire account and not just for Stash's rooms. You can also request an admin to change your StashDB username instead (see below).
+You will also be **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access.
 
-If you would like to **change your StashDB username**, please contact a StashDB admin on Discord/Matrix (preferably **@AdultSun** on Discord). You may be asked to DM the email address you used to join StashDB in order for the admin to verify your account. An admin may also ask you to pick a new username before granting edit access if there is any concern about your current username.
+You may also [join our Discord]({{ site.baseurl }}/docs/faq_getting-started/stashdb/joining-discord-and-matrix/) if you'd like, but this is **not required** for StashDB editors. As a result, not all mods, admins, and devs will be available there.
 
-If we cannot reach you through StashDB comments, Discord, or Matrix, **your [edit rights may be revoked by an admin]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) after repeated violations of our guidelines**. But don't worry about memorizing all of the guidelines right away. Just try to start slowly with a few submissions at a time, watch for comments or messages on Discord/Matrix, and [update your edits]({{ site.baseurl }}/docs/faq_getting-started/edits/updating-edits/) when necessary. You can also ask in the **#stashdb-general** channels on Discord/Matrix if you have any questions.
+**For Discord users**, we require your nickname (also called "display name") in our server to match your StashDB username. You can either [go to your user settings](https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames){:target="_blank"} or type the shortcut `/nick <your-new-username>` into any channel of Stash's Discord server. This will only change the name displayed inside of Stash's Discord and not anywhere else. You may also request an admin to change your StashDB username instead (see below).
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, politely ask for edit access in the [**#stashdb-invites** channel on Discord](https://discord.com/channels/559159668438728723/935614155107471442){:target="_blank"} or in the [**StashDB - Invites** room on Matrix](https://matrix.to/#/#stashdb-invites:unredacted.org){:target="_blank"}, provide your StashDB username, and wait patiently. Once an admin has granted edit access, they will respond with a thumbs up 👍 react or (occasionally) a direct reply. This shouldn't take any longer than a day or two and will often happen much sooner. If you fail to follow any of these instructions, someone will direct you back to this webpage and you must try again.
+If you would like to **change your StashDB username**, please contact a StashDB admin on Discourse/Discord (preferably **@AdultSun**) and ask them politely to change it for you. You may be asked to DM the email address you used to join StashDB in order for the admin to verify your account. If there is any concern about your username, an admin may ask you to pick a different one before granting edit access.
+
+## Guidelines Summary
+
+All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely -- even if you think the topic is irrelevant to you -- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
+
+### **Start slowly.**
+
+Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes.
+
+Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes. Read more about the process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
+
+### **Use helpful edit comments.**
+
+You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources. Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
+
+### **Update pending edits.**
+
+If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
+
+### **No underage performers.**
+
+Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/). Please DM an admin immediately if you see any underage content on StashDB.
+
+### **No banned studios.**
+
+In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time. Please DM an admin immediately if you see any banned content on StashDB.
+
+### **No ineligible performer aliases.**
+
+All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves. These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible. If you see a suspicious name on StashDB, please DM an admin immediately.
+
+### **Review your drafts.**
+
+When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
+
+### **Generate pHashes.**
+
+Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/). Speaking of secret sauces, do you have a favorite ice cream topping? Be sure to include your answer as an "additional comment" in your application, don't tell anyone else, and keep reading.
+
+### **Ineligible movie scenes.**
+
+All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/). Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
+
+### **Exceptions for amateur content.**
+
+All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/). Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
+
+### **Exceptions for JAV content.**
+
+Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline. We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
+
+### **Add or create missing performers.**
+
+All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
+
+### **Check for duplicates first.**
+
+The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
+
+### **Familiarize yourself with our disciplinary process.**
+
+At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first. Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine. Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
+
+## Submitting Your Request
+
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, politely ask for edit access in Discourse using the link below. Remember to answer every question in the request form and wait patiently. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse. If you fail to follow **any part** of these instructions, your application may be rejected. The admin reviewing your request might not explain why. You must return here and carefully read the entire article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -95,32 +95,32 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ### 1.) No underage performers.
 
-> Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
-
 {: .note-title }
 > Important!
 >
 > **If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
-### 2.) No banned studios.
+> Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
 
-> In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
+### 2.) No banned studios.
 
 {: .note-title }
 > Important!
 >
 > **If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
-### 3.) No ineligible performer aliases.
+> In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
 
-> All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
-> 
-> These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
+### 3.) No ineligible performer aliases.
 
 {: .note-title }
 > Important!
 >
 > **If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
+
+> All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
+> 
+> These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
 
 ---
 
@@ -172,16 +172,16 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ## Moderation and Enforcement
 
+{: .note-title }
+> Important!
+>
+> **If you see any behavior that should result in the loss of edit access, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
+
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first.
 
 Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine.
 
 Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
-
-{: .note-title }
-> Important!
->
-> **If you see any behavior that should result in the loss of edit access, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ---
 

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -35,7 +35,8 @@ First, make sure you have an account on **StashDB.org**. It's easy to confuse it
 
 All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access. The website can be found here:
 
-[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank" .btn .btn-blue }
+{: .important }
+[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank"}
 
 ### Filling out your Discourse profile
 
@@ -67,11 +68,11 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ### 1.) Start slowly.
 
-> {: .note-title }
-> > Important!
-> >
-> > **Do not start by submitting 20+ edits immediately after gaining edit access. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
-> 
+{: .note-title }
+> Important!
+>
+> **Do not start by submitting 20+ edits immediately after gaining edit access. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
+
 > Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes.
 > 
 > Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes.
@@ -95,31 +96,31 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 ### 1.) No underage performers.
 
 > Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
-> 
-> {: .note-title }
-> > Important!
-> >
-> > **If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
+
+{: .note-title }
+> Important!
+>
+> **If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ### 2.) No banned studios.
 
 > In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
-> 
-> {: .note-title }
-> > Important!
-> >
-> > **If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
+
+{: .note-title }
+> Important!
+>
+> **If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ### 3.) No ineligible performer aliases.
 
 > All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
 > 
 > These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
-> 
-> {: .note-title }
-> > Important!
-> >
-> > **If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
+
+{: .note-title }
+> Important!
+>
+> **If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ---
 

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -137,7 +137,7 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 ### 10. Exceptions for amateur content.
 
 > All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
-
+>
 > Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
 ### 11. Exceptions for JAV content.
@@ -174,8 +174,8 @@ If you are aware of any behavior that you believe would justify revoking someone
 
 ## Submitting Your Request
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the link at the bottom of this page named "APPLICATION FORM". Then, click the "Request" button in the top-right corner of the page. Make sure to fill out the entire form, but please keep your answers brief. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the button at the bottom of this page. Then, click the "Request" button in the top-right corner. Make sure to fill out the entire form, but please keep your answers brief. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
 
 If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
 
-[APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){: .btn .btn-blue }
+[APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank" .btn .btn-blue }

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -56,7 +56,7 @@ If you've already created an account, you'll have to dig into your settings to a
 - You must add your **StashDB username** to your Discourse profile.
     - If you want to change your StashDB username, you can ask for a new one within the edit request form. If that's the case, add your new StashDB username to Discourse **before submitting your edit request**.
 - If you've joined any other public stash-boxes, please add those usernames as well.
-- If you've joined the Stash Discord server, please add your **server nickname** (also called **display name**).
+- If you've joined the Stash Discord server, please add your **unique username** (not your **server nickname** or **display name**).
     - Editors are **not required** to join Discord.
     - Editors are **not required** to "Log in with Discord" or "Connect" Discord to their account.
 - We recommend that your name on StashDB, Discourse, and Discord all match in order to limit confusion.

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -35,7 +35,7 @@ First, make sure you have an account on **StashDB.org**. It's easy to confuse it
 
 All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access. The website can be found here:
 
-[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank"}
+[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank" .btn }
 
 ### Filling out your Discourse profile
 
@@ -47,44 +47,44 @@ If you've already created an account, you'll have to dig into your settings to a
 
 ### Requirements for StashDB editors:
 
-- Your **Discourse username** must be the same as your **StashDB username**.
-    - Don't worry about the field labelled **Name (optional)**, that's not the same as your **username**. You can put an alternative name in there if you want, but you can also safely ignore it.
-- You must add your **StashDB username**. Again, this must be the same as your **Discourse username**.
-- If you've joined the Stash Discord server, you must add your **server nickname** (also called **display name**).
+- You must add your **StashDB username** to your Discourse profile.
+- If you've joined any other public stash-boxes, please add those usernames as well.
+- If you've joined the Stash Discord server, please add your **server nickname** (also called **display name**).
     - Editors are **not required** to join Discord.
-    - Editors active in Stash's Discord must have their **server nickname** match their **StashDB username**.
-    - Editors are not required to "**Log in with Discord**" or "**Connect**" Discord to their account.
+    - Editors are **not required** to "Log in with Discord" or "Connect" Discord to their account.
+- We recommend that your name on StashDB, Discourse, and Discord all match in order to limit confusion.
 - If you want to change your StashDB username, you can ask for a new one within the edit request form.
-    - Discourse and Discord must match the **new** StashDB username **before requesting edit access**. If these names don't match, you're request may be rejected.
 
 ---
 
 # Guidelines Summary
 
-All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
+All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks within each section.
 
 ---
 
 ## Basic Procedure
 
-### 1. Start slowly.
+### 1.) Start slowly.
 
-> Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes. This is worth repeating.
->
-> {: .warning }
-> **Do not start by submitting 20+ edits at once. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
+> {: .note }
+> > Important!
+> >
+> > **Do not start by submitting 20+ edits immediately after gaining edit access. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
+> 
+> Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes.
 > 
 > Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes.
 > 
-> Voting rights will be automatically granted after your 10th approved submission. You can read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
+> Voting rights will be automatically granted after your 10th approved submission. Read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
 
-### 2. Use helpful edit comments.
+### 2.) Use helpful edit comments.
 
 > You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources.
 > 
 > Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
  
-### 3. Update pending edits.
+### 3.) Update pending edits.
 
 > If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
 
@@ -92,69 +92,80 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ## Banned Content
 
-### 4. No underage performers.
+### 1.) No underage performers.
 
 > Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
 > 
-> If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
+> {: .note }
+> > Important!
+> >
+> > **If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
-### 5. No banned studios.
+### 2.) No banned studios.
 
 > In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
 > 
-> If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
+> {: .note }
+> > Important!
+> >
+> > **If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
-### 6. No ineligible performer aliases.
+### 3.) No ineligible performer aliases.
 
 > All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
 > 
 > These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
 > 
-> If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
+> {: .note }
+> > Important!
+> >
+> > **If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ---
 
 ## Common Mistakes
 
-### 7. Review your drafts.
+### 1.) Review your drafts.
 
-> When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. 
+> When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours.
 > 
-> Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
+> Navigate to your draft in StashDB and make sure everything is accurate and complete before submitting it to the edit queue. Some info saved in Stash might be missing from the draft, and other kinds of data will need to be manually added. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
+> 
+> Currently, drafts are the only way to add new scenes to StashDB.
 
-### 8. Generate pHashes.
+### 2.) Generate pHashes.
 
 > Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/).
 > 
 > Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with something to think about while you wait. Based on its cultural impact and role in creating the modern adult industry, Deep Throat is the greatest porn video of all time. To make sure you’re paying attention, we will reject any applications that disagree. Remember this before you submit your request, don’t mention it to anyone without edit access, and keep reading.
 
-### 9. Ineligible movie scenes.
+### 3.) Ineligible movie scenes.
 
 > All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
 > 
 > Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
-### 10. Exceptions for amateur content.
+### 4.) Exceptions for amateur content.
 
 > All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
 >
 > Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
-### 11. Exceptions for JAV content.
+### 5.) Exceptions for JAV content.
 
 > Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline.
 > 
 > We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
 
-### 12. Add or create missing performers.
+### 6.) Add or create missing performers.
 
 > All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. Requirements for performers in scene creation edits are further explained in [Missing Performers]({{ site.baseurl }}/docs/scenes/edit/scene-performers/missing-performers/).
 > 
 > If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
 
-### 13. Check for duplicates first.
+### 7.) Check for duplicates first.
 
-> The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
+> Duplicate scenes and studios can be much harder to remove than duplicate performers, so please pay extra attention in those areas. The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
 
 ---
 
@@ -166,14 +177,19 @@ Always act with the best interests of the community in mind. Make your best effo
 
 Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
 
-If you are aware of any behavior that you believe would justify revoking someone's edit access, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
+{: .note }
+> Important!
+>
+> **If you see any behavior that should result in the loss of edit access, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.**
 
 ---
 
 ## Submitting Your Request
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the button at the bottom of this page. Then, click the "Request" button in the top-right corner. Make sure to fill out the entire form, but please keep your answers brief. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the button at the bottom of this page. Then, click the "Request" button in the top-right corner. Make sure to fill out the entire form, but please keep your answers brief.
 
-If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
+An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+
+If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article. Make sure you follow every instruction to the letter, however insignificant it may seem. You may submit a new request no sooner than 1 hour after your previous one.
 
 [APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank" .btn .btn-blue }

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -158,9 +158,7 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ---
 
-## Fair Warning
-
-### Moderation and enforcement.
+## Moderation and Enforcement
 
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first.
 

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -23,6 +23,7 @@ Permissions to create, modify, merge, or destroy tags will require separate perm
 **Please read the following sections carefully. Failing to follow these instructions may result in delays, rejections, or the loss of future editing privileges.**
 
 ---
+---
 
 ## Make a StashDB Account
 
@@ -34,7 +35,7 @@ First, make sure you have an account on **StashDB.org**. It's easy to confuse it
 
 All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access. The website can be found here:
 
-https://discourse.stashapp.cc/
+[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank"}
 
 ### Filling out your Discourse profile
 
@@ -47,55 +48,60 @@ If you've already created an account, you'll have to dig into your settings to a
 ### Requirements for StashDB editors:
 
 1. Your **Discourse username** must be the same as your **StashDB username**.
-  1. Don't worry about the field labelled **Name (optional)**, that's not the same as your **username**. You can put an alternative name in there if you want, but you can also safely ignore it.
-1. You must add your **StashDB username**. Again, this must be the same as your **Discourse username**.
-1. If you've joined the Stash Discord server, you must add your **server nickname** (also called **display name**).
-  1. Editors are **not required** to join Discord.
-  1. Editors active in Stash's Discord must have their **server nickname** match their **StashDB username**.
-  1. Editors are not required to "**Log in with Discord**" or "**Connect**" Discord to their account.
-1. If you want to change your StashDB username, you can ask for a new one within the edit request form.
-  1. Discourse and Discord must match the **new** StashDB username **before requesting edit access**. If these names don't match, you're request may be rejected.
+    a. Don't worry about the field labelled **Name (optional)**, that's not the same as your **username**. You can put an alternative name in there if you want, but you can also safely ignore it.
+2. You must add your **StashDB username**. Again, this must be the same as your **Discourse username**.
+3. If you've joined the Stash Discord server, you must add your **server nickname** (also called **display name**).
+    a. Editors are **not required** to join Discord.
+    b. Editors active in Stash's Discord must have their **server nickname** match their **StashDB username**.
+    c. Editors are not required to "**Log in with Discord**" or "**Connect**" Discord to their account.
+4. If you want to change your StashDB username, you can ask for a new one within the edit request form.
+    a. Discourse and Discord must match the **new** StashDB username **before requesting edit access**. If these names don't match, you're request may be rejected.
 
+---
 ---
 
 ## Guidelines Summary
 
 All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
 
-### **1. Start slowly.**
+### Basic Procedure
+
+#### **1.** Start slowly.
+
+Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes. This is worth repeating.
 
 {: .warning }
 **Do not start by submitting 20+ edits at once. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
-
-Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes.
 
 Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes.
 
 Voting rights will be automatically granted after your 10th approved submission. You can read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
 
-### **2. Use helpful edit comments.**
+#### **2.** Use helpful edit comments.
 
 You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources.
 
 Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
 
-### **3. Update pending edits.**
+#### **3.** Update pending edits.
 
 If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
 
-### **4. No underage performers.**
+### Banned Content
+
+#### **4.** No underage performers.
 
 Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
 
 Please DM an admin immediately if you see any underage content on StashDB.
 
-### **5. No banned studios.**
+#### **5.** No banned studios.
 
 In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
 
 Please DM an admin immediately if you see any banned content on StashDB.
 
-### **6. No ineligible performer aliases.**
+#### **6.** No ineligible performer aliases.
 
 All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
 
@@ -103,45 +109,53 @@ These requirements are explained in more detail in [Eligible Aliases]({{ site.ba
 
 If you see a suspicious name on StashDB, please DM an admin immediately.
 
-### **7. Review your drafts.**
+### Common Mistakes
+
+#### **7.** Review your drafts.
 
 When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. 
 
 Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
 
-### **8. Generate pHashes.**
+#### **8.** Generate pHashes.
 
-Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/). Speaking of secret sauces, do you have a favorite ice cream topping? Be sure to include your answer as an "additional comment" in your application, don't tell anyone else, and keep reading.
+Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/).
 
-### **9. Ineligible movie scenes.**
+Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with something to think about while you wait. Based on its cultural impact and role in creating the modern adult industry, Deep Throat is the greatest porn video of all time. To make sure you’re paying attention, we will reject any applications that disagree. Remember this before you submit your request, don’t mention it to anyone without edit access, and keep reading.
+
+#### **9.** Ineligible movie scenes.
 
 All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
 
 Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
-### **10. Exceptions for amateur content.**
+#### **10.** Exceptions for amateur content.
 
 All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
 
 Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
-### **11. Exceptions for JAV content.**
+#### **11.** Exceptions for JAV content.
 
 Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline.
 
 We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
 
-### **12. Add or create missing performers.**
+#### **12.** Add or create missing performers.
 
 All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. Requirements for performers in scene creation edits are further explained in [Missing Performers]({{ site.baseurl }}/docs/scenes/edit/scene-performers/missing-performers/).
 
 If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
 
-### **13. Check for duplicates first.**
+#### **13.** Check for duplicates first.
 
 The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
 
-### **14. Moderation and enforcement.**
+---
+
+### Fair Warning
+
+#### **14.** Moderation and enforcement.
 
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first.
 
@@ -150,11 +164,13 @@ Always act with the best interests of the community in mind. Make your best effo
 Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
 
 ---
+---
 
 ## Submitting Your Request
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the link at the bottom of this page named "APPLICATION FORM" and log into Discourse. Then, click the "Request" button in the top right corner of the page. The application form will pop up. Make sure to answer all 10 questions in the request form, but please keep your answers brief. Double-check your answers and click "Submit Request" once you're finished. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the link at the bottom of this page named "APPLICATION FORM". Then, click the "Request" button in the top-right corner of the page. Make sure to answer fill out the entire form, but please keep your answers brief. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
 
-If you fail to follow **any part** of these instructions, your application may be rejected. Most likely, an admin will direct you back to this article. If you would like to try again, you must first carefully re-read the entire article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
+If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
 
+{: .important }
 [APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank"}

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -15,9 +15,15 @@ grand_parent: FAQ / Getting Started
 
 Every StashDB account is able to [submit fingerprints/hashes]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/) from within the [Scene Tagger](https://docs.stashapp.cc/beginner-guides/guide-to-scraping/#use-the-scene-tagger){:target="_blank"} view of Stash. This does not require any additional permissions. However, if you would like to add or edit any scenes/performers/studios, you will need to be granted additional privileges.
 
-The process for gaining edit access is simple. First, you must read this **entire** article carefully and closely, following **all** of its instructions. After you finish reading, you must fill out a short application form. Every request will be reviewed individually by one of the admins. There will be an opportunity to reapply if your first request is rejected. The application process is described in more detail within this article and should take about 15-20 minutes, mostly depending on how fast you can read.
+The process for gaining edit access is simple. First, you must read this **entire** article carefully and closely, following **all** of its instructions. Failing to do so could result in the rejection of your application or the loss of edit rights in the future, so take your time. After you finish reading, you must fill out a short application form. 
+
+Typically, the application process takes only 10--15 minutes to complete. That estimate includes reading this entire guide, following all of its instructions, and completing the request form.
+
+Every request will be reviewed individually by one of StashDB's admins. There will be an opportunity to reapply if your first request is rejected.
 
 Permissions to create, modify, merge, or destroy tags will require separate permissions. The exact process is still TBD. If you are interested, DM **@AdultSun** for more information.
+
+---
 
 {: .warning }
 **Please read the following sections carefully. Failing to follow these instructions may result in delays, rejections, or the loss of future editing privileges.**
@@ -35,8 +41,7 @@ First, make sure you have an account on **StashDB.org**. It's easy to confuse it
 
 All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access. The website can be found here:
 
-{: .important }
-[https://discourse.stashapp.cc/](https://discourse.stashapp.cc/){:target="_blank"}
+[STASHAPP DISCOURSE](https://discourse.stashapp.cc/){:target="_blank" .btn .btn-blue }
 
 ### Filling out your Discourse profile
 
@@ -60,7 +65,9 @@ If you've already created an account, you'll have to dig into your settings to a
 
 # Guidelines Summary
 
-All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely and carefully --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks within each section.
+All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely and carefully --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. Again, failing to do so could result in the rejection of your application or the loss of edit rights in the future.
+
+If you'd like to learn more about a particular subject, further information can be found by clicking on the hyperlinks within each section.
 
 ---
 
@@ -138,11 +145,11 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 > Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/).
 > 
-> Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with something to think about while you wait. Based on its cultural impact and role in creating the modern adult industry, Deep Throat is the greatest porn video of all time. To make sure you’re paying attention, we will reject any applications that disagree. Remember this before you submit your request, don’t mention it to anyone without edit access, and keep reading.
+> Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with a warning while you wait. The application will ask how you learned about StashDB. To make sure you’re paying attention, we will reject any applications that don’t include this phrase in their answer: “I’ve always known about StashDB.” You may still answer honestly if you’d like, but you must include that exact phrase in your response. Remember this before you submit your request and please don’t mention it to anyone without edit access.
 
 ### 3.) Ineligible movie scenes.
 
-> All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
+> All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. That also means physical releases (VHS, DVD, BluRay, etc.) with only 3rd party databases as a source (IAFD, Data18, TPDB, IMDB, etc.) are also not eligible. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
 > 
 > Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
@@ -191,6 +198,6 @@ Requesting edit access is not difficult. **After you've read and followed all of
 
 An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
 
-If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, first re-read this **entire** article closely and carefully. Make sure you follow every instruction to the letter, however insignificant it may seem. You may submit a new request no sooner than 1 hour after your previous one.
+If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, first re-read this **entire** article closely and carefully. Make sure you follow every instruction to the letter, however insignificant it may seem. You may submit a new request no sooner than 1 hour after your previous rejection.
 
 [APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank" .btn .btn-blue }

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -142,8 +142,8 @@ At the discretion of the admins, your edit access may be revoked at any time. Ho
 
 ## Submitting Your Request
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, log into Discourse and click the link at the bottom of this page. Then, click the "Request" button in the top right corner of the page. The application form will pop up. Make sure to answer all 10 questions in the request form, but please keep your answers brief. Double-check your answers and click "Submit Request" once you're finished. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the link at the bottom of this page named "APPLICATION FORM" and log into Discourse. Then, click the "Request" button in the top right corner of the page. The application form will pop up. Make sure to answer all 10 questions in the request form, but please keep your answers brief. Double-check your answers and click "Submit Request" once you're finished. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
 
 If you fail to follow **any part** of these instructions, your application may be rejected. Most likely, an admin will direct you back to this article. If you would like to try again, you must first carefully re-read the entire article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
 
-https://discourse.stashapp.cc/g/stashdb_editors
+[APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank"}

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -23,7 +23,7 @@ Permissions to create, modify, merge, or destroy tags will require separate perm
 **Please read the following sections carefully. Failing to follow these instructions may result in delays, rejections, or the loss of future editing privileges.**
 
 ---
----
+
 
 ## Make a StashDB Account
 
@@ -47,26 +47,26 @@ If you've already created an account, you'll have to dig into your settings to a
 
 ### Requirements for StashDB editors:
 
-1. Your **Discourse username** must be the same as your **StashDB username**.
-    a. Don't worry about the field labelled **Name (optional)**, that's not the same as your **username**. You can put an alternative name in there if you want, but you can also safely ignore it.
-2. You must add your **StashDB username**. Again, this must be the same as your **Discourse username**.
-3. If you've joined the Stash Discord server, you must add your **server nickname** (also called **display name**).
-    a. Editors are **not required** to join Discord.
-    b. Editors active in Stash's Discord must have their **server nickname** match their **StashDB username**.
-    c. Editors are not required to "**Log in with Discord**" or "**Connect**" Discord to their account.
-4. If you want to change your StashDB username, you can ask for a new one within the edit request form.
-    a. Discourse and Discord must match the **new** StashDB username **before requesting edit access**. If these names don't match, you're request may be rejected.
+- Your **Discourse username** must be the same as your **StashDB username**.
+    - Don't worry about the field labelled **Name (optional)**, that's not the same as your **username**. You can put an alternative name in there if you want, but you can also safely ignore it.
+- You must add your **StashDB username**. Again, this must be the same as your **Discourse username**.
+- If you've joined the Stash Discord server, you must add your **server nickname** (also called **display name**).
+    - Editors are **not required** to join Discord.
+    - Editors active in Stash's Discord must have their **server nickname** match their **StashDB username**.
+    - Editors are not required to "**Log in with Discord**" or "**Connect**" Discord to their account.
+- If you want to change your StashDB username, you can ask for a new one within the edit request form.
+    - Discourse and Discord must match the **new** StashDB username **before requesting edit access**. If these names don't match, you're request may be rejected.
 
----
 ---
 
 ## Guidelines Summary
 
 All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
 
-### Basic Procedure
+{: .highlight }
+Basic Procedure
 
-#### **1.** Start slowly.
+### **1.** Start slowly.
 
 Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes. This is worth repeating.
 
@@ -77,31 +77,32 @@ Everything you submit will sit in the edit queue where other editors can review 
 
 Voting rights will be automatically granted after your 10th approved submission. You can read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
 
-#### **2.** Use helpful edit comments.
+### **2.** Use helpful edit comments.
 
 You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources.
 
 Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
 
-#### **3.** Update pending edits.
+### **3.** Update pending edits.
 
 If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
 
-### Banned Content
+{: .highlight }
+Banned Content
 
-#### **4.** No underage performers.
+### **4.** No underage performers.
 
 Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
 
 Please DM an admin immediately if you see any underage content on StashDB.
 
-#### **5.** No banned studios.
+### **5.** No banned studios.
 
 In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
 
 Please DM an admin immediately if you see any banned content on StashDB.
 
-#### **6.** No ineligible performer aliases.
+### **6.** No ineligible performer aliases.
 
 All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
 
@@ -109,53 +110,53 @@ These requirements are explained in more detail in [Eligible Aliases]({{ site.ba
 
 If you see a suspicious name on StashDB, please DM an admin immediately.
 
-### Common Mistakes
+{: .highlight }
+Common Mistakes
 
-#### **7.** Review your drafts.
+### **7.** Review your drafts.
 
 When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. 
 
 Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
 
-#### **8.** Generate pHashes.
+### **8.** Generate pHashes.
 
 Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/).
 
 Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with something to think about while you wait. Based on its cultural impact and role in creating the modern adult industry, Deep Throat is the greatest porn video of all time. To make sure you’re paying attention, we will reject any applications that disagree. Remember this before you submit your request, don’t mention it to anyone without edit access, and keep reading.
 
-#### **9.** Ineligible movie scenes.
+### **9.** Ineligible movie scenes.
 
 All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
 
 Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
-#### **10.** Exceptions for amateur content.
+### **10.** Exceptions for amateur content.
 
 All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
 
 Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
-#### **11.** Exceptions for JAV content.
+### **11.** Exceptions for JAV content.
 
 Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline.
 
 We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
 
-#### **12.** Add or create missing performers.
+### **12.** Add or create missing performers.
 
 All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. Requirements for performers in scene creation edits are further explained in [Missing Performers]({{ site.baseurl }}/docs/scenes/edit/scene-performers/missing-performers/).
 
 If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
 
-#### **13.** Check for duplicates first.
+### **13.** Check for duplicates first.
 
 The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
 
----
+{: .highlight }
+Fair Warning
 
-### Fair Warning
-
-#### **14.** Moderation and enforcement.
+### **14.** Moderation and enforcement.
 
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first.
 
@@ -164,11 +165,10 @@ Always act with the best interests of the community in mind. Make your best effo
 Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
 
 ---
----
 
 ## Submitting Your Request
 
-Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the link at the bottom of this page named "APPLICATION FORM". Then, click the "Request" button in the top-right corner of the page. Make sure to answer fill out the entire form, but please keep your answers brief. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
+Requesting edit access is not difficult. **After you've read and followed all of the instructions above**, click the link at the bottom of this page named "APPLICATION FORM". Then, click the "Request" button in the top-right corner of the page. Make sure to fill out the entire form, but please keep your answers brief. An admin will review your application shortly, usually within a day or two. You will see their response as a notification within Discourse.
 
 If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
 

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -67,102 +67,108 @@ All editors of StashDB are expected to follow our guidelines to ensure a high le
 
 ## Basic Procedure
 
-### **1.** Start slowly.
+### 1. Start slowly.
 
-Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes. This is worth repeating.
+> Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes. This is worth repeating.
+>
+> {: .warning }
+> **Do not start by submitting 20+ edits at once. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
+> 
+> Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes.
+> 
+> Voting rights will be automatically granted after your 10th approved submission. You can read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
 
-{: .warning }
-**Do not start by submitting 20+ edits at once. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
+### 2. Use helpful edit comments.
 
-Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes.
+> You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources.
+> 
+> Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
+ 
+### 3. Update pending edits.
 
-Voting rights will be automatically granted after your 10th approved submission. You can read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
-
-### **2.** Use helpful edit comments.
-
-You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources.
-
-Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
-
-### **3.** Update pending edits.
-
-If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
+> If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
 
 ---
 
 ## Banned Content
 
-### **4.** No underage performers.
+### 4. No underage performers.
 
-Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
+> Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
+> 
+> If you see any underage content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
 
-Please DM an admin immediately if you see any underage content on StashDB.
+### 5. No banned studios.
 
-### **5.** No banned studios.
+> In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
+> 
+> If you see any banned content on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
 
-In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
+### 6. No ineligible performer aliases.
 
-Please DM an admin immediately if you see any banned content on StashDB.
+> All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
+> 
+> These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
+> 
+> If you see a suspicious name on StashDB, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
 
-### **6.** No ineligible performer aliases.
-
-All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
-
-These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
-
-If you see a suspicious name on StashDB, please DM an admin immediately.
+---
 
 ## Common Mistakes
 
-### **7.** Review your drafts.
+### 7. Review your drafts.
 
-When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. 
+> When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. 
+> 
+> Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
 
-Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
+### 8. Generate pHashes.
 
-### **8.** Generate pHashes.
+> Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/).
+> 
+> Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with something to think about while you wait. Based on its cultural impact and role in creating the modern adult industry, Deep Throat is the greatest porn video of all time. To make sure you’re paying attention, we will reject any applications that disagree. Remember this before you submit your request, don’t mention it to anyone without edit access, and keep reading.
 
-Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit any scenes to the queue without generating a pHash first, you will need to either resubmit the edit or add your fingerprints after the scene is approved. More info on pHashes and how to generate them can be found in [What's a pHash?]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/).
+### 9. Ineligible movie scenes.
 
-Generating pHashes can take a long time if you have a large collection or slow hardware, so I’ll leave you with something to think about while you wait. Based on its cultural impact and role in creating the modern adult industry, Deep Throat is the greatest porn video of all time. To make sure you’re paying attention, we will reject any applications that disagree. Remember this before you submit your request, don’t mention it to anyone without edit access, and keep reading.
+> All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
+> 
+> Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
-### **9.** Ineligible movie scenes.
+### 10. Exceptions for amateur content.
 
-All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
+> All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
 
-Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
+> Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
-### **10.** Exceptions for amateur content.
+### 11. Exceptions for JAV content.
 
-All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
+> Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline.
+> 
+> We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
 
-Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
+### 12. Add or create missing performers.
 
-### **11.** Exceptions for JAV content.
+> All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. Requirements for performers in scene creation edits are further explained in [Missing Performers]({{ site.baseurl }}/docs/scenes/edit/scene-performers/missing-performers/).
+> 
+> If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
 
-Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline.
+### 13. Check for duplicates first.
 
-We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
+> The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
 
-### **12.** Add or create missing performers.
-
-All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. Requirements for performers in scene creation edits are further explained in [Missing Performers]({{ site.baseurl }}/docs/scenes/edit/scene-performers/missing-performers/).
-
-If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
-
-### **13.** Check for duplicates first.
-
-The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
+---
 
 ## Fair Warning
 
-### **14.** Moderation and enforcement.
+### Moderation and enforcement.
 
 At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first.
 
 Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine.
 
 Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
+
+If you are aware of any behavior that you believe would justify revoking someone's edit access, [please DM an admin immediately](https://discourse.stashapp.cc/g/stashdb_admins){:target="_blank"}.
 
 ---
 
@@ -172,5 +178,4 @@ Requesting edit access is not difficult. **After you've read and followed all of
 
 If you fail to follow **any part** of these instructions, your application may be rejected. If you would like to try again, you must first carefully re-read this **entire** article to find what requirement you may have missed, however small it may seem. You may submit a new request no sooner than 24 hours after your previous one.
 
-{: .important }
-[APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){:target="_blank"}
+[APPLICATION FORM](https://discourse.stashapp.cc/g/stashdb_editors){: .btn .btn-blue }

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -59,12 +59,13 @@ If you've already created an account, you'll have to dig into your settings to a
 
 ---
 
-## Guidelines Summary
+# Guidelines Summary
 
 All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
 
-{: .highlight }
-Basic Procedure
+---
+
+## Basic Procedure
 
 ### **1.** Start slowly.
 
@@ -87,8 +88,9 @@ Fortunately, most edits are relatively straightforward and only use a single sou
 
 If you made a mistake or missed an important piece of information, another editor may downvote your edit and explain why in a comment. These will appear as notifications in the navigation bar across the top of StashDB. When this happens, you are expected to update your edit with the required changes. This will reset the current vote total and notify all commenters and voters of the update.
 
-{: .highlight }
-Banned Content
+---
+
+## Banned Content
 
 ### **4.** No underage performers.
 
@@ -110,8 +112,7 @@ These requirements are explained in more detail in [Eligible Aliases]({{ site.ba
 
 If you see a suspicious name on StashDB, please DM an admin immediately.
 
-{: .highlight }
-Common Mistakes
+## Common Mistakes
 
 ### **7.** Review your drafts.
 
@@ -153,8 +154,7 @@ If the performer does not exist in the database already, they will need to be cr
 
 The underlying Stash-Box software will automatically warn you of any duplicates based on title/name and fingerprints, but this doesn't catch everything. A quick search with a few carefully chosen keywords only takes a few seconds and could save everyone a lot of wasted time and effort as a result.
 
-{: .highlight }
-Fair Warning
+## Fair Warning
 
 ### **14.** Moderation and enforcement.
 

--- a/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
+++ b/docs/faq_getting-started/stashdb/contributing-to-stashdb.md
@@ -13,9 +13,11 @@ grand_parent: FAQ / Getting Started
 
 ---
 
-Every StashDB account is able to [submit fingerprints/hashes]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/) from within the [Scene Tagger](https://docs.stashapp.cc/beginner-guides/guide-to-scraping/#use-the-scene-tagger){:target="_blank"} view of Stash. This does not require any additional permissions. However, if you would like to add or edit any scenes/performers/studios/tags, you will need to be granted additional privileges.
+Every StashDB account is able to [submit fingerprints/hashes]({{ site.baseurl }}/docs/faq_getting-started/stashdb/whats-a-phash/) from within the [Scene Tagger](https://docs.stashapp.cc/beginner-guides/guide-to-scraping/#use-the-scene-tagger){:target="_blank"} view of Stash. This does not require any additional permissions. However, if you would like to add or edit any scenes/performers/studios, you will need to be granted additional privileges.
 
 The process for gaining edit access is simple. First, you must read this **entire** article carefully and closely, following **all** of its instructions. After you finish reading, you must fill out a short application form. Every request will be reviewed individually by one of the admins. There will be an opportunity to reapply if your first request is rejected. The application process is described in more detail within this article and should take about 15-20 minutes, mostly depending on how fast you can read.
+
+Permissions to create, modify, merge, or destroy tags will require separate permissions. The exact process is still TBD. If you are interested, DM **@AdultSun** for more information.
 
 {: .warning }
 **Please read the following sections carefully. Failing to follow these instructions may result in delays, rejections, or the loss of future editing privileges.**
@@ -24,71 +26,58 @@ The process for gaining edit access is simple. First, you must read this **entir
 
 ## Make a StashDB Account
 
-First, make sure you have an account on **StashDB.org**. There are other public stash-boxes that look very similar, but those are all hosted separately and require different accounts. We can't apply the EDIT role to an account that doesn't exist yet. Please see our guide to [Accessing StashDB]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stashdb/) if you need any help finding an invite code, registering an account, or connecting it to Stash.
+First, make sure you have an account on **StashDB.org**. It's easy to confuse it with [other public stash-boxes]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stash-boxes/), but they all require separate accounts. We can't apply the EDIT role to an account that doesn't exist yet. Please see our guide to [Accessing StashDB]({{ site.baseurl }}/docs/faq_getting-started/stashdb/accessing-stashdb/) if you need any help finding an invite code, registering an account, or connecting it to Stash.
 
 ---
 
 ## Make a Discourse Account
 
-All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access.
+All editors are **required to join our Discourse server**. This is the home to Stash's forums and will be the primary method for editors, mods, and admins to communicate with each other. You will also use Discourse to submit your request for edit access. The website can be found here:
 
-If you've already created in account in Discourse, you will need to fill out your profile before requesting edit access. This will link all of your related profiles together for easy reference. While you're there, make sure your Discourse username matches your StashDB username. If you have joined our Discord server, your nickname there must match as well. All three names (StashDB, Discord, Discourse) must be the same in order to be granted edit access.
-
-The following sections will walk you through all of these steps. Follow whichever guide is relevant to you.
-
-### **If you have not joined our Discourse server:**
-Visit the following link and click on the "Sign Up" button in the top-right corner:
 https://discourse.stashapp.cc/
 
-A registration form will pop up. Fill out it out, following these instructions:
-1. Provide an email address. Discourse will send you an activation email, so make sure you have access to it. Please note, this address will be visible to our admins on the server.
-1. Provide a username for Discourse. For StashDB editors, this **username** must match your StashDB username.
-1. You'll see a field labelled "Name (optional)". You can **ignore** this field. It may be used for any alternative name you would like listed in your profile, but it is not required. It is not a username or a display name and does not need to match any other accounts.
-1. Add your StashDB username. Again, this must match your Discourse **username** to gain edit access.
-1. If you have joined our Discord server, add your **nickname** (also called "display name") in the field labelled "Discord (optional)". Editors are **not required** to join our Discord. However, for anyone on Discord with edit access, this nickname must also match your StashDB username.
-1. You are **not required** to link your Discord or GitHub accounts by clicking either of the "Log in with..." buttons to the right. If you want to contribute to the Stash project as a dev, then linking GitHub could be helpful. Otherwise, you can ignore both buttons.
-1. If you've created accounts on any other stash-boxes, you may add those usernames next. None of these other usernames are required to match your name on StashDB, Discourse, or Discord.
-1. One last time, make sure your StashDB, Discourse, and Discord names match. If you need help changing any of these, keep reading.
+### Filling out your Discourse profile
 
-### **If you've already joined our Discourse:**
-Log into Discourse and make sure your profile is filled out, following these instructions:
-1. Click on your circular avatar in the top-right. In the pop-up, click on the profile icon in the bottom-right corner, then click "Preferences" next to the gear icon to the left. Finally, click on the "Profile" tab near the top of the page. Scroll down past the field labelled "Web Site".
-1. Add your StashDB username. This must match your Discourse **username** to gain edit access.
-1. If you have joined our Discord server, add your **nickname** (also called "display name") in the field labelled "Discord (optional)". Editors are **not required** to join our Discord. However, for anyone on Discord with edit access, this nickname must also match your StashDB username.
-1. If you've created accounts on any other stash-boxes, you may add those usernames next. None of these other usernames are required to match your name on StashDB, Discourse, or Discord.
-1. One last time, make sure your StashDB, Discourse, and Discord names match. If you need help changing any of these, keep reading.
+You will need to fill out your Discourse profile page before requesting edit access. There are a few details and requirements that StashDB editors need to keep in mind, listed in the next section.
 
-### **If you need to change your StashDB username:**
-First, decide what your new StashDB username will be. Make sure your Discourse username and Discord nickname match this new StashDB username **before** requesting edit access. You will be able to request a new StashDB username as part of your application. If approved, an admin will change your username and grant edit permissions at the same time. If there is any concern about your username, an admin may ask you to pick a different one before granting edit access.
+If you're creating a new account, all of these details are part of the initial registration form.
 
-If you want to change your StashDB username at any time **after** receiving edit access, you will need to send an admin a DM to politely ask them to change it for you. You will need to provide your current StashDB username, your new StashDB username, and the email linked to your StashDB account. Your email is used to verify the account and is only visible to admins. If you can't remember the exact address, log into StashDB and click on your username near the top-right corner.
+If you've already created an account, you'll have to dig into your settings to add these details. First, click on your avatar and navigate to _Profile_ > _Preferences_. You can change your Discourse username under the _Account_ tab. All of the other fields are under the _Profile_ tab.
 
-### **If you need to change your Discourse username:**
-All editors are required to have matching names on StashDB and Discourse. If you want to change your Discourse username to match your StashDB username, you must change it **before** requesting edit access, following these instructions:
-1. Log into Discourse and click on your circular avatar in the top-right. In the pop-up, click on the profile icon in the bottom-right corner, then click "Preferences" next to the gear icon to the left.
-1. Near the top of the page, click the pencil icon underneath "Username". Change this to match your StashDB username.
-1. Further down, you'll see a field laballed "Name". You can **ignore** this field. It may be used for any alternative name you would like listed in your profile, but it is not required. It is not a username or a display name and does not need to match any other accounts.
+### Requirements for StashDB editors:
 
-### **If you need to change your Discord username:**
-Editors are **not required** to join our Discord. However, for anyone on Discord with edit access, this nickname must also match your StashDB username. If you want to change your Discord username to match your StashDB username, you must change it **before** requesting edit access.
-
-This can be done one of two ways. You can either go to your user settings to [change your server nicknames](https://support.discord.com/hc/en-us/articles/219070107-Server-Nicknames){:target="_blank"}, or type the shortcut `/nick <your-new-username>` into any channel of Stash's Discord server. Both methods only change the name displayed inside of Stash's Discord. It will not change your username or display name anywhere else on Discord.
+1. Your **Discourse username** must be the same as your **StashDB username**.
+  1. Don't worry about the field labelled **Name (optional)**, that's not the same as your **username**. You can put an alternative name in there if you want, but you can also safely ignore it.
+1. You must add your **StashDB username**. Again, this must be the same as your **Discourse username**.
+1. If you've joined the Stash Discord server, you must add your **server nickname** (also called **display name**).
+  1. Editors are **not required** to join Discord.
+  1. Editors active in Stash's Discord must have their **server nickname** match their **StashDB username**.
+  1. Editors are not required to "**Log in with Discord**" or "**Connect**" Discord to their account.
+1. If you want to change your StashDB username, you can ask for a new one within the edit request form.
+  1. Discourse and Discord must match the **new** StashDB username **before requesting edit access**. If these names don't match, you're request may be rejected.
 
 ---
 
 ## Guidelines Summary
 
-All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely -- even if you think the topic is irrelevant to you -- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
+All editors of StashDB are expected to follow our guidelines to ensure a high level of quality in their submissions. This website is home to an extensive number of requirements, recommendations, tips, and guides. You are **not** expected to memorize all of them right away. However, you **must** be familiar with the following list of guidelines **before submitting your request for edit access**. Read each section closely --- even if you think the topic is irrelevant to you --- before moving on to the next part of this article. If you'd like to learn more, further information can be found by clicking the hyperlinks to other articles.
 
 ### **1. Start slowly.**
 
+{: .warning }
+**Do not start by submitting 20+ edits at once. Repeated guideline violations and bulk submissions without permission can result in the loss of edit privileges.**
+
 Do not attempt to submit a large batch of edits immediately after gaining edit access. Take your time, try to keep your first submissions simple and small, and leave only a few edits pending at a time. Double-check the guidelines or ask on Discourse/Discord if you have any questions. And *always* keep an eye on the notifications bell for any comments or downvotes.
 
-Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes. Read more about the process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
+Everything you submit will sit in the edit queue where other editors can review them, voting for either approval or rejection. Everything goes much quicker and smoother when pending edits don't need any corrections. So, be patient and give yourself time to learn the ropes.
+
+Voting rights will be automatically granted after your 10th approved submission. You can read more about the approval process in [Voting on StashDB]({{ site.baseurl }}/docs/faq_getting-started/edits/voting/) before voting on anything yourself.
 
 ### **2. Use helpful edit comments.**
 
-You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources. Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
+You will not be able to submit your edit without including a comment first, so make it count. You will be expected to describe where you've sourced your data and explain why your data may be different compared to those sources.
+
+Fortunately, most edits are relatively straightforward and only use a single source, so there won't be much to explain. Typical comments for these kinds of edits include "scraped from studio" or "male performer from visual ID". For anything more complex, try to be as direct in your explanations as possible to make it easier for voters to parse. You can also use Markdown syntax to better format your comment.
 
 ### **3. Update pending edits.**
 
@@ -96,19 +85,29 @@ If you made a mistake or missed an important piece of information, another edito
 
 ### **4. No underage performers.**
 
-Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/). Please DM an admin immediately if you see any underage content on StashDB.
+Any content including underage performers will never be allowed on StashDB. We ensure this by only allowing scenes from performers, studios, and platforms that follow age verification laws. These requirements are detailed in [Performer Eligibility]({{ site.baseurl }}/docs/performers/create/performer-eligibility/).
+
+Please DM an admin immediately if you see any underage content on StashDB.
 
 ### **5. No banned studios.**
 
-In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time. Please DM an admin immediately if you see any banned content on StashDB.
+In rare circumstances, StashDB admins may ban specific studios based on legality and consent. Anything from a studio with a pattern of violating their performers' consent (i.e., Girls Do Porn) is not allowed. All specific bans will be listed under [Banned Studios]({{ site.baseurl }}/docs/studios/create/banned-studios/). This list may expand over time.
+
+Please DM an admin immediately if you see any banned content on StashDB.
 
 ### **6. No ineligible performer aliases.**
 
-All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves. These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible. If you see a suspicious name on StashDB, please DM an admin immediately.
+All performer names and aliases must be used as an official adult credit in order to be eligible. This means that any legal names or given names cannot be included as an alias just because it is publically known, reported, or even revealed by performers themselves.
+
+These requirements are explained in more detail in [Eligible Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/eligible-aliases/). To be safe, do not add any [Suspicious Aliases]({{ site.baseurl }}/docs/performers/edit/performer-aliases/suspicious-aliases/) that cannot be verified as eligible.
+
+If you see a suspicious name on StashDB, please DM an admin immediately.
 
 ### **7. Review your drafts.**
 
-When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
+When you create an edit by clicking the "Submit to Stash-Box" option within Stash, it is not immediately submitted for approval. It is temporarily saved as a "draft" on StashDB and will expire after 24 hours. 
+
+Make sure everything in your draft is accurate and complete before submitting it to the edit queue. Some info saved in Stash might not be included when generating the draft, and other kinds of data may need to be manually added. Currently, drafts are the only way to add new scenes to StashDB. Further instructions can be found in [How to Submit Drafts from Stash]({{ site.baseurl }}/docs/faq_getting-started/drafts/submit-from-stash/#how-to-submit-drafts-from-stash).
 
 ### **8. Generate pHashes.**
 
@@ -116,19 +115,27 @@ Perceptual hashes are the "secret sauce" behind Stash and StashDB. If you submit
 
 ### **9. Ineligible movie scenes.**
 
-All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/). Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
+All scenes must be sourced from a 1st party digital studio. This means any scenes or movies sourced exclusively from a 3rd party retailer for rent or sale (i.e., Adult DVD Empire, Hot Movies, etc.) are not eligible for inclusion on StashDB at this time. Requirements for eligibility are explained in more detail for both [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) and [Split Movie Scenes]({{ site.baseurl }}/docs/scenes/create/split-movie-scenes/).
+
+Please note that some websites act as both 1st party producers and 3rd party retailers simultaneously. In situations where a website acts as both a 1st party producer and a 3rd party retailer, only original content produced by the studio itself is eligible. For example, the only eligible scenes from Bang.com come from the [sub-studios listed under "Bang! Originals"](https://stashdb.org/studios/e653a89f-6794-4243-a748-2d808647d2d3){:target="_blank"}.
 
 ### **10. Exceptions for amateur content.**
 
-All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/). Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
+All amateur scenes must use the creator as its studio, not the platform. Also, only certain amateur platforms (ManyVids, Clips4Sale, PornHub, MFC Share, etc.) are allowed. Paywalled subscription services (OnlyFans, Just for Fans, Patreon, etc.) are not allowed. Eligibility for amateur content is explained further in [Amateur Studios]({{ site.baseurl }}/docs/studios/create/amateur-studios/).
+
+Also note that a single scene entry on StashDB may be used to cover multiple platforms, as explained in [Remasters, Redistributions, and Re-Releases]({{ site.baseurl }}/docs/scenes/create/re-releases/).
 
 ### **11. Exceptions for JAV content.**
 
-Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline. We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
+Since JAV is almost exclusively released as full movie downloads, it has been granted an exception under our [Full Movie Entries]({{ site.baseurl }}/docs/scenes/create/full-movie-entries/) guideline.
+
+We also have specific requirements on the formatting of [JAV Names]({{ site.baseurl }}/docs/performers/edit/performer-name/jav-names/).
 
 ### **12. Add or create missing performers.**
 
-All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
+All performers listed by the studio must be included in your scene submission. This includes male performers in straight scenes. Requirements for performers in scene creation edits are further explained in [Missing Performers]({{ site.baseurl }}/docs/scenes/edit/scene-performers/missing-performers/).
+
+If the performer does not exist in the database already, they will need to be created *before* submitting the scene. Identifying uncredited performers is not required but strongly recommended whenever possible.
 
 ### **13. Check for duplicates first.**
 
@@ -136,7 +143,11 @@ The underlying Stash-Box software will automatically warn you of any duplicates 
 
 ### **14. Moderation and enforcement.**
 
-At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first. Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine. Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
+At the discretion of the admins, your edit access may be revoked at any time. However, this is rare and usually comes with an official warning first.
+
+Always act with the best interests of the community in mind. Make your best effort to follow the guidelines, correcting any mistakes when asked. Remain civil and constructive in all communications. If you can do that, you'll be fine.
+
+Our article explaining [StashDB Moderation Enforcement]({{ site.baseurl }}/docs/faq_getting-started/edits/moderation-enforcement/) details what behaviors may result in disciplinary action. It also addresses how and when edit access may be restored.
 
 ---
 


### PR DESCRIPTION
- Describes new application process for gaining edit access, now using recently launched Discourse forum
- Establishes new set of requirements for editors, mostly making Discord optional and Discourse mandatory
- Adds rundown of most important and most relevant sections of the guidelines for new editors