### PR TITLE
Modify "Missing Performers" guidelines based on Discourse discussion

### DIFF
--- a/docs/scenes/edit/scene-performers/missing-performers.md
+++ b/docs/scenes/edit/scene-performers/missing-performers.md
@@ -13,7 +13,7 @@ grand_parent: Edit Scenes
 
 ---
 
-All active performers listed in the details, title, URL, or a linked webpage should be included when adding or editing a scene. This includes male performers in straight scenes. Please note in your edit comment why any performers are not included in your submission. Finding names for missing performers on recommended databases (IAFD, Data18, etc.) is greatly encouraged, but often not required.
+All performers listed in the title, details, URL, or a linked webpage should be included when adding or editing a scene. This includes male performers in straight scenes. In the cases where performers who appear in scenes are not listed on the studio website you are encouraged (but not required) to find them by cross-referencing other metadata databases such as [IAFD](https://www.iafd.com/), [DATA18](https://www.data18.com/), [GEVI](https://gayeroticvideoindex.com/), etc. Please note in your edit comment why any performers are not included in your submission and add the relevant "Missing Performer ([Female](https://stashdb.org/tags/9ed214ad-f04f-4e7f-adc2-1d62c16fbcdb), [Male](https://stashdb.org/tags/38d88a3d-c22f-4b5b-a876-72a1f824481c), [Trans](https://stashdb.org/tags/2d80491c-1f2b-42e2-8ee3-45c13f6aa271))" tags to the scene.
 
 {: .note }
 Unconfirmed guideline, subject to change pending formal approval.


### PR DESCRIPTION
This changes the guidelines for the "Missing Performers" page when creating/editing scenes to match the guidelines proposed on the Discourse forum at: https://discourse.stashapp.cc/t/missing-performers-clarify-tagging-expectations/2404